### PR TITLE
fix: bug#2

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,9 +1,10 @@
-import { useState } from "react";
-import { NavLink } from "react-router-dom";
-import { RiCloseLine } from "react-icons/ri";
-import logo from "../assets/logo2.jpg";
-import { links } from "../assets/constants";
-import { HiOutlineMenu } from "react-icons/hi";
+import { useState } from 'react';
+import { NavLink } from 'react-router-dom';
+import { RiCloseLine } from 'react-icons/ri';
+import { HiOutlineMenu } from 'react-icons/hi';
+import logo from '../assets/logo2.jpg';
+import { links } from '../assets/constants';
+
 const NavLinks = ({ handleClick }) => (
   <div className="mt-10 ">
     {links.map((link) => (
@@ -12,6 +13,7 @@ const NavLinks = ({ handleClick }) => (
         to={link.to}
         onClick={() => handleClick && handleClick()}
         className="flex flex-row justify-start items-center my-8 text-sm font-medium text-gray-400 hover:text-cyan-400"
+        end={link.to === '/'}
       >
         <link.icon className="w-6 h-6 mr-2" />
         {link.name}
@@ -42,7 +44,7 @@ const Sidebar = () => {
       </div>
       <div
         className={`absolute top-0 h-screen w-2/3 bg-gradient-to-tl from-white/10 to-[#483d8b] backdrop-blur-lg z-10 p-6 md:hidden smooth-transition ${
-          mobileMenuOpen ? "left-0" : "-left-full"
+          mobileMenuOpen ? 'left-0' : '-left-full'
         }`}
       >
         <img className="w-full h-14 object-contain" src={logo} alt="logo" />


### PR DESCRIPTION
The NavLink from ReactRouterDom has a prop ```end``` to make sure that a path is not matched if the entire path is not matched. What was happening was every other path included ```/``` in the start, so it was always counted. It is fixed now. 